### PR TITLE
Unbold tagline elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,10 +16,10 @@
          class="w-48 h-48 mb-8 rounded-full object-cover shadow-lg border-4 border-white"/>
     <h1 class="text-4xl md:text-5xl font-bold mb-3">Mohammed Abu Maaliq</h1>
     <p class="text-xl md:text-2xl font-medium mb-6">
-      Creative Writer • Philosopher • <span class="text-indigo-600">AI Orchestrator</span>
+      Creative Writer • Philosopher • AI Orchestrator
     </p>
     <p class="max-w-2xl text-lg md:text-xl leading-relaxed mb-8">
-      A space where literature, philosophy, <span class="font-semibold">art</span>, and artificial intelligence converge<br/>
+      A space where literature, philosophy, art, and artificial intelligence converge<br/>
       to inspire change and ignite human wisdom and creativity.
     </p>
     <a href="#about"
@@ -33,7 +33,7 @@
     <div class="container mx-auto px-6">
       <h2 class="text-3xl font-semibold mb-6 text-center">About</h2>
       <p class="max-w-3xl mx-auto text-lg leading-relaxed">
-        Mohammed Abu Maaliq is a creative writer, philosopher, and <strong>AI Orchestrator</strong>
+        Mohammed Abu Maaliq is a creative writer, philosopher, and AI Orchestrator
         dedicated to weaving narratives that spark imagination while exploring how
         technology can enhance human wisdom and creativity.
       </p>


### PR DESCRIPTION
## Summary
- remove color highlight from "AI Orchestrator" in hero tagline
- stop emphasizing "art"
- strip `<strong>` tags in the About section

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688bedc73a0c832b967cf03b293c0608