### PR TITLE
Add Pinterest icon below Get in Touch button

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,7 @@
           </ul>
         </div>
     </div>
+      </div>
   </section>
 
   <!-- ===== CONTACT ===== -->
@@ -99,6 +100,9 @@
          class="inline-block px-6 py-2 bg-[#b08968] text-white rounded shadow hover:bg-[#9c7a5f] transition">
          Get in Touch
       </a>
+        <a href="https://www.pinterest.com/philomoha77/_saved/" target="_blank" rel="noopener noreferrer">
+          <img src="assets/images/pinrest.jpeg" alt="Pinterest" class="w-10 h-10 mx-auto mt-4"/>
+        </a>
     </div>
   </section>
   <!-- ===== FOOTER ===== -->


### PR DESCRIPTION
## Summary
- add link to Pinterest board below the Get in Touch button
- close an unclosed div in the services section to validate markup

## Testing
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_688e3f496b5c832b9b84dc4d504529b5