### PR TITLE
Increase Pinterest icon size below Get in Touch

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
          Get in Touch
       </a>
         <a href="https://www.pinterest.com/philomoha77/_saved/" target="_blank" rel="noopener noreferrer">
-          <img src="assets/images/pinrest.jpeg" alt="Pinterest" class="w-10 h-10 mx-auto mt-4"/>
+          <img src="assets/images/pinrest.jpeg" alt="Pinterest" class="w-20 h-20 mx-auto mt-4"/>
         </a>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- enlarge Pinterest icon under Get in Touch to 80x80 using Tailwind classes `w-20 h-20`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f9636e8c0832b8cad5cbaaddf38ca